### PR TITLE
[Ready to be deployed] Prepare plugins

### DIFF
--- a/app/controllers/stability_controller.rb
+++ b/app/controllers/stability_controller.rb
@@ -6,9 +6,11 @@ class StabilityController < ApplicationController
     @version = params[:version]
 
     all_names = select_all_names
+    all_plugins = select_all_plugins
     @tool_select_groups = {
       'Tools' => TOOLS,
-      'Actions' => all_names - TOOLS
+      'Actions' => all_names - TOOLS - all_plugins,
+      'Plugins' => all_plugins
     }
 
     @summary = select_summary_info(@tool)
@@ -19,6 +21,14 @@ class StabilityController < ApplicationController
     Bacon.where("tool_version <> 'unknown'").
       pluck(:action_name).
       map(&:downcase). # Unfortunately we have values like "FASTLANE" and 'Fastlane'
+      uniq.
+      sort
+  end
+
+  def select_all_plugins
+    Bacon.where("action_name LIKE :prefix", prefix: "fastlane-plugin-%").
+      pluck(:action_name).
+      map(&:downcase).
       uniq.
       sort
   end

--- a/app/controllers/stability_controller.rb
+++ b/app/controllers/stability_controller.rb
@@ -26,7 +26,7 @@ class StabilityController < ApplicationController
   end
 
   def select_all_plugins
-    Bacon.where("action_name LIKE :prefix", prefix: "fastlane-plugin-%").
+    Bacon.where("action_name LIKE fastlane-plugin-%").
       pluck(:action_name).
       map(&:downcase).
       uniq.

--- a/app/views/stability/index.html.erb
+++ b/app/views/stability/index.html.erb
@@ -110,5 +110,3 @@ $('#tool_select').on('change', function() {
 <%- end %>
 </tbody>
 </table>
-
-<h4><a href="https://github.com/fastlane/enhancer" target="_blank">View the source code of 'enhancer'</a></h4>


### PR DESCRIPTION
This PR adds support for third party plugins. This way we can easily see what plugins cause a high number of crashes.

<img width="250" alt="screenshot 2016-05-21 17 03 44" src="https://cloud.githubusercontent.com/assets/869950/15451430/eaa42bea-1f76-11e6-86a2-92f08c088442.png">

---

<img width="862" alt="screenshot 2016-05-21 17 03 33" src="https://cloud.githubusercontent.com/assets/869950/15451429/ea8db7de-1f76-11e6-8053-b65328af5b7b.png">

**Note** how we even get the failure rate per action, inside a plugin. This way we can detect a high failure rate with an update (see row of version 0.2.1) early 🚀 
