### PR TITLE
Pass the generated Fastfile ID and success/failure to the analytic ingester

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem 'chart-js-rails' # nice HTML5 graphs
 
 gem 'table_for_collection'
 
+gem 'faraday'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
     debug_inspector (0.0.2)
     erubis (2.7.0)
     execjs (2.7.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
@@ -75,6 +77,7 @@ GEM
     mini_portile2 (2.1.0)
     minitest (5.9.0)
     multi_json (1.12.1)
+    multipart-post (2.0.0)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
@@ -159,6 +162,7 @@ DEPENDENCIES
   byebug
   chart-js-rails
   coffee-rails (~> 4.1.0)
+  faraday
   jbuilder (~> 2.0)
   jquery-rails
   pg
@@ -174,4 +178,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.12.4
+   1.12.5


### PR DESCRIPTION
`fastfile_id` will be sent from _fastlane_ when a Fastfile was generated by an automated tool. This will allow us to understand how often they succeed vs. fail.