### PR TITLE
Remove the /graphs route, because it can cause the app to die

### DIFF
--- a/app/controllers/bacons_controller.rb
+++ b/app/controllers/bacons_controller.rb
@@ -120,45 +120,4 @@ class BaconsController < ApplicationController
   def versions
     @versions ||= JSON.parse(params[:versions]) rescue {}
   end
-
-  def ran
-    Random.rand(255)
-  end
-
-  def graphs
-    @data = {}
-    @days = []
-    start_time = Time.at(1428883200) # the first day
-
-    values = []
-    Bacon.all.order(:launch_date).each do |bacon|
-      counter = (bacon.launch_date.to_date - start_time.to_date).to_i
-
-      values[counter] ||= {launches: 0, errors: 0}
-      values[counter][:launches] += bacon.launches
-      values[counter][:errors] += bacon.number_errors
-
-      formatted_string = bacon.launch_date.strftime("%d.%m.%Y")
-      @days << formatted_string unless @days.include?formatted_string
-    end
-
-    # Fill nils with 0
-    values.each_with_index do |k, index|
-      puts k
-      values[index] = (k[:errors].to_f / k[:launches].to_f * 100 rescue 0).round
-    end
-
-    @data[0] ||= {
-      label: "Success Rate",
-      fillColor: "rgba(220,220,220,0.2)",
-      strokeColor: "rgba(220,220,220)",
-      pointColor: "rgba(220,220,220)",
-      pointStrokeColor: "#fff",
-      pointHighlightFill: "#fff",
-      pointHighlightStroke: "rgba(220,220,220,1)",
-      data: values
-    }
-  end
-
-
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,6 @@ Rails.application.routes.draw do
 
   root to: 'bacons#stats'
   get 'index' => 'bacons#stats'
-  get 'graphs' => 'bacons#graphs'
   post 'did_launch' => 'bacons#did_launch'
   get 'stability' => 'stability#index'
 end


### PR DESCRIPTION
Trying to load this route makes the app throw out-of-memory errors, and then stop being able to service any requests.