### PR TITLE
Add cutoff date for stats page

### DIFF
--- a/app/controllers/bacons_controller.rb
+++ b/app/controllers/bacons_controller.rb
@@ -85,16 +85,17 @@ class BaconsController < ApplicationController
   end
 
   def stats
-    launches = Bacon.group(:action_name).sum(:launches)
-    number_errors = Bacon.group(:action_name).sum(:number_errors)
+    bacon_actions = Bacon.group(:action_name)
 
     if params[:weeks]
       num_weeks = params[:weeks].to_i
       cutoff_date = num_weeks.weeks.ago
 
-      launches = launches.where("launch_date >= :cutoff_date", { cutoff_date: cutoff_date })
-      number_errors = number_errors.where("launch_date >= :cutoff_date", { cutoff_date: cutoff_date })
+      bacon_actions = bacon_actions.where("launch_date >= :cutoff_date", { cutoff_date: cutoff_date })
     end
+
+    launches = bacon_actions.sum(:launches)
+    number_errors = bacon_actions.sum(:number_errors)
 
     @sums = []
     launches.each do |action, _|

--- a/app/controllers/bacons_controller.rb
+++ b/app/controllers/bacons_controller.rb
@@ -88,6 +88,14 @@ class BaconsController < ApplicationController
     launches = Bacon.group(:action_name).sum(:launches)
     number_errors = Bacon.group(:action_name).sum(:number_errors)
 
+    if params[:weeks]
+      num_weeks = params[:weeks].to_i
+      cutoff_date = num_weeks.weeks.ago
+
+      launches.where("launch_date >= :cutoff_date", { cutoff_date: cutoff_date })
+      number_errors.where("launch_date >= :cutoff_date", { cutoff_date: cutoff_date })
+    end
+
     @sums = []
     launches.each do |action, _|
       entry = {

--- a/app/controllers/bacons_controller.rb
+++ b/app/controllers/bacons_controller.rb
@@ -92,8 +92,8 @@ class BaconsController < ApplicationController
       num_weeks = params[:weeks].to_i
       cutoff_date = num_weeks.weeks.ago
 
-      launches.where("launch_date >= :cutoff_date", { cutoff_date: cutoff_date })
-      number_errors.where("launch_date >= :cutoff_date", { cutoff_date: cutoff_date })
+      launches = launches.where("launch_date >= :cutoff_date", { cutoff_date: cutoff_date })
+      number_errors = number_errors.where("launch_date >= :cutoff_date", { cutoff_date: cutoff_date })
     end
 
     @sums = []


### PR DESCRIPTION
This makes it so one can append `?weeks=4` to the URL and only the last 4 weeks will be shown. Useful so we can evaluate which actions are actually in use currently.