### PR TITLE
Add filtering for action names

### DIFF
--- a/app/controllers/bacons_controller.rb
+++ b/app/controllers/bacons_controller.rb
@@ -87,6 +87,11 @@ class BaconsController < ApplicationController
   def stats
     bacon_actions = Bacon.group(:action_name)
 
+    if params[:only]
+      only_show = params[:only].is_a?(Array) ? params[:only] : [params[:only]]
+      bacon_actions = bacon_actions.where(action_name: only_show)
+    end
+
     if params[:weeks]
       num_weeks = params[:weeks].to_i
       cutoff_date = num_weeks.weeks.ago


### PR DESCRIPTION
Adds the `only` param to the url, so either do:

- `?only=<action>`: Only shows info for <action>
- `?only[]=<action1>&only[]=<action2>&only[]=...`: Only show <action1>, <action2>, ... 

Example for the url `?only[]=ipa&only[]=deploygate&only[]=testfairy&only[]=hockey&weeks=4`:

<img width="906" alt="screenshot 2016-12-01 16 26 20" src="https://cloud.githubusercontent.com/assets/279407/20818567/52b9df4a-b7e3-11e6-94ac-2994686c17c4.png">
