### PR TITLE
Add graphs to show the stability per tool-version

### DIFF
--- a/app/controllers/stability_controller.rb
+++ b/app/controllers/stability_controller.rb
@@ -131,7 +131,6 @@ class StabilityController < ApplicationController
   end
 
   def select_details_info(tool)
-    date_limit = 7.days.ago.to_date
     date_limit = 6.months.ago.to_date
 
     select_statement = [

--- a/app/controllers/stability_controller.rb
+++ b/app/controllers/stability_controller.rb
@@ -15,6 +15,85 @@ class StabilityController < ApplicationController
 
     @summary = select_summary_info(@tool)
     @details = select_details_info(@tool).group_by(&:launch_date)
+
+    # Generate the data we need to show stability grouped by version, instead of date
+    @graph_data = {}
+    minimum_launches_to_show_in_graph = nil # we don't want to show the crash rate of a version that's only used once in the last month or so
+    
+    # Now detect the minimum launches we need to show a version
+    @details.each do |_, bacon_list|
+      bacon_list.each do |current_bacon|
+        current_i = current_bacon.launches * 0.04
+
+        if minimum_launches_to_show_in_graph.nil? || current_i > minimum_launches_to_show_in_graph
+          minimum_launches_to_show_in_graph = current_i
+        end
+      end
+    end
+
+    @details.each do |_, bacon_list|
+      bacon_list.each do |current_bacon|
+        next if current_bacon.launches < minimum_launches_to_show_in_graph
+
+        @graph_data[current_bacon[:tool_version]] ||= {
+          number_user_errors: 0,
+          number_crashes: 0,
+          launches: 0
+        }
+        @graph_data[current_bacon[:tool_version]][:number_user_errors] += current_bacon.number_user_errors
+        @graph_data[current_bacon[:tool_version]][:number_crashes] += current_bacon.number_crashes
+        @graph_data[current_bacon[:tool_version]][:launches] += current_bacon.launches
+      end
+    end
+
+    @graph_data = @graph_data.sort { |x, y| Gem::Version.new(x.first) <=>  Gem::Version.new(y.first) }.to_h
+
+    # @graph_data => {"1.105.3"=>{:number_user_errors=>1225, :number_crashes=>267, :launches => 123123},
+    #                 "1.108.0"=>{:number_user_errors=>2195, :number_crashes=>430, :launches => 884743},
+    #                 ...
+
+    @versions = @graph_data.keys # needed for the graph
+    @raw_graph = [
+      {
+        label: "Crashes",
+        fillColor: "rgba(220,220,220,0.2)",
+        backgroundColor: "rgba(220,220,220,0.07)",
+        borderColor: "red",
+        pointStrokeColor: "#fff",
+        pointHitRadius: 10,
+        pointHighlightFill: "#fff",
+        pointHighlightStroke: "rgba(220,220,220,1)",
+        data: @graph_data.collect do |_, a|
+          (a[:number_crashes].to_f / a[:launches]).round(3) * 100
+        end
+      },
+      {
+        label: "User Errors",
+        fillColor: "rgba(220,220,220,0.2)",
+        backgroundColor: "rgba(220,220,220,0.07)",
+        borderColor: "orange",
+        pointStrokeColor: "#fff",
+        pointHitRadius: 10,
+        pointHighlightFill: "#fff",
+        pointHighlightStroke: "rgba(220,220,220,1)",
+        data: @graph_data.collect do |_, a|
+          (a[:number_user_errors].to_f / a[:launches]).round(3) * 100
+        end
+      },
+      {
+        label: "Success",
+        fillColor: "rgba(220,220,220,0.2)",
+        backgroundColor: "rgba(220,220,220,0.07)",
+        borderColor: "green",
+        pointStrokeColor: "#fff",
+        pointHitRadius: 10,
+        pointHighlightFill: "#fff",
+        pointHighlightStroke: "rgba(220,220,220,1)",
+        data: @graph_data.collect do |_, a|
+          ((a[:launches] - a[:number_user_errors] - a[:number_crashes]).to_f / a[:launches]).round(3) * 100
+        end
+      }
+    ]
   end
 
   def select_all_names
@@ -53,6 +132,7 @@ class StabilityController < ApplicationController
 
   def select_details_info(tool)
     date_limit = 7.days.ago.to_date
+    date_limit = 6.months.ago.to_date
 
     select_statement = [
       "action_name",

--- a/app/views/stability/index.html.erb
+++ b/app/views/stability/index.html.erb
@@ -65,6 +65,30 @@ $('#tool_select').on('change', function() {
 </tbody>
 </table>
 
+<h3>Stability per version in %</h3>
+<canvas id="stability"></canvas>
+
+<!-- Javascript lol -->
+<script type="text/javascript">
+  function generateGraph(sel, data, labels) {
+    var ctx = $(sel).get(0).getContext("2d");
+    var data = {
+      labels: labels,
+      datasets: data
+    };
+    var myLineChart = new Chart(ctx , {
+      type: "line",
+      data: data,
+      scaleBeginAtZero: true,
+      responsive: true,
+      animation : false,
+      multiTooltipTemplate: "<\%= datasetLabel %> - <\%= value %>"
+  });
+  }
+
+  generateGraph("#stability", <%= raw(@raw_graph.to_json) %>, <%= raw(@versions) %>)
+</script>
+
 <h3>Details</h3>
 
 <%- if @version %>


### PR DESCRIPTION
Show the stability per page, which enables us to detect regressions after pushing a new release. 

<img width="1507" alt="screenshot 2016-12-01 18 27 04" src="https://cloud.githubusercontent.com/assets/869950/20844569/558974be-b875-11e6-9334-40922704fecc.png">

---- 

<img width="1346" alt="screenshot 2016-12-01 18 19 14" src="https://cloud.githubusercontent.com/assets/869950/20844572/58efc392-b875-11e6-9c02-e8cf5b359162.png">
