### PR TITLE
Fix the minimum value calculations and truncate

### DIFF
--- a/app/controllers/bacons_controller.rb
+++ b/app/controllers/bacons_controller.rb
@@ -71,7 +71,7 @@ class BaconsController < ApplicationController
       bacon_actions = bacon_actions.where("launch_date >= :cutoff_date", cutoff_date: cutoff_date)
     end
 
-    @minimum_launches = params[:minimum_launches].to_i || 50 * params[:weeks].to_i
+    @minimum_launches = (params[:minimum_launches] || (params[:weeks] || 4).to_i * 50).to_i
 
     # Selects the sums and action name without converting into a Bacon object
     launch_info = bacon_actions.pluck("sum(number_errors)", "sum(launches)", "sum(number_crashes)", :action_name)
@@ -81,7 +81,7 @@ class BaconsController < ApplicationController
       next if launches < @minimum_launches
       entry = {
         action: action,
-        action_short: action.gsub("fastlane-plugin-", "plugin-"),
+        action_short: action.gsub("fastlane-plugin-", "plugin-").truncate(50),
         launches: launches,
         errors: errors,
         ratio: (errors.to_f / launches.to_f).round(3),

--- a/app/views/bacons/stats.html.erb
+++ b/app/views/bacons/stats.html.erb
@@ -6,10 +6,6 @@
   th { 
     font-weight: bold;
   }
-  td {
-    white-space: nowrap; text-overflow:ellipsis; overflow: hidden; 
-    max-width:800px;
-  }
 
   .red { background-color: #C55; }
   .orange { background-color: orange; }
@@ -22,7 +18,7 @@
 <p>This is the number of times an action was run and compared to the number of errors this action caused. More information on <a href="https://github.com/fastlane/enhancer" target="_blank">GitHub</a></p>
 
 <table>
-  <tr style="width:20%">
+  <tr>
     <td style="padding-right: 20px">
       By # Launches
       <%= table_for @by_launches, html: {


### PR DESCRIPTION
- This will truncate names that are too long
- This will fix that the "crashes" column wasn't visible
- This fixes the minimum value calculations