### PR TITLE
Move all data update work to a resque worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ FL_PASSWORD=[password used to see the web dashboard]
 
 Heroku uses something called a `Procfile` to track multiple processes that you want have started up, and a gem called `foreman` knows how to run these things for you locally
 
-* Run `bundle exec foreman start` to start up the `web` and `worker` processes
+* Run `RAILS_ENV=development bundle exec foreman start` to start up the `web` and `worker` processes
 
 ```
 $ bundle exec foreman start

--- a/app/controllers/bacons_controller.rb
+++ b/app/controllers/bacons_controller.rb
@@ -12,26 +12,7 @@ class BaconsController < ApplicationController
     end
 
     # Store the number of runs per action
-    now = Time.now.to_date
-    launches.each do |action, count|
-      entry = Bacon.find_or_create_by(action_name: action, launch_date: now, tool_version: tool_version(action))
-      entry.increment(:launches, count)
-      entry.save
-    end
-
-    if params[:error].present?
-      update_bacon_for(params[:error], now) do |bacon|
-        bacon.increment(:number_errors)
-        bacon.save
-      end
-    end
-
-    if params[:crash].present?
-      update_bacon_for(params[:crash], now) do |bacon|
-        bacon.increment(:number_crashes)
-        bacon.save
-      end
-    end
+    Resque.enqueue(BaconUpdaterWorker, launches, params[:error], params[:crash])
 
     # Only report analytic ingester events for fastlane tool launches
     if launches.size == 1 && launches['fastlane']
@@ -47,13 +28,6 @@ class BaconsController < ApplicationController
     return unless ENV['ANALYTIC_INGESTER_URL'].present? && fastfile_id.present?
 
     Resque.enqueue(AnalyticIngesterWorker, fastfile_id, error, crash)
-  end
-
-  def update_bacon_for(action_name, launch_date)
-    version = tool_version(action_name)
-    Bacon.find_by(action_name: action_name, launch_date: launch_date, tool_version: version).try do |bacon|
-      yield bacon
-    end
   end
 
   def stats
@@ -113,13 +87,5 @@ class BaconsController < ApplicationController
       format.html # renders the matching template
       format.json { render json: @by_launches }
     end
-  end
-
-  def tool_version(name)
-    versions[name] || 'unknown'
-  end
-
-  def versions
-    @versions ||= JSON.parse(params[:versions]) rescue {}
   end
 end

--- a/app/workers/bacon_updater_worker.rb
+++ b/app/workers/bacon_updater_worker.rb
@@ -1,0 +1,50 @@
+class BaconUpdaterWorker
+  @queue = :bacon_updater
+
+  ActiveRecord::Base.logger = Logger.new(STDOUT)
+
+  def self.perform(launches, error, crash)
+    puts "Starting bacons update for launches: #{launches}, error: #{error}, crash: #{crash}"
+
+    # Returns any connections in use by the current thread back to the pool, and also returns
+    # connections to the pool cached by threads that are no longer alive.
+    ActiveRecord::Base.clear_active_connections!
+
+    now = Time.now.to_date
+    launches.each do |action, count|
+      entry = Bacon.find_or_create_by(action_name: action, launch_date: now, tool_version: tool_version(action))
+      entry.increment(:launches, count)
+      entry.save
+    end
+
+    if error.present?
+      update_bacon_for(error, now) do |bacon|
+        bacon.increment(:number_errors)
+        bacon.save
+      end
+    end
+
+    if crash.present?
+      update_bacon_for(crash, now) do |bacon|
+        bacon.increment(:number_crashes)
+        bacon.save
+      end
+    end
+
+    puts "Finished bacons update for launches: #{launches}, error: #{error}, crash: #{crash}"
+  end
+
+  def self.update_bacon_for(action_name, launch_date)
+    Bacon.find_by(action_name: action_name, launch_date: launch_date, tool_version: tool_version(action_name)).try do |bacon|
+      yield bacon
+    end
+  end
+
+  def self.tool_version(name)
+    versions[name] || 'unknown'
+  end
+
+  def self.versions
+    @versions ||= JSON.parse(params[:versions]) rescue {}
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,6 @@
+# Helps foreman output Rails logging immediately instead of buffering it
+$stdout.sync = true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 


### PR DESCRIPTION
This means that the web controller's only real job is to enqueue data for handling in the worker process.

At this time, it is still important that we keep only a single worker pulling and executing work.