### PR TITLE
Fix handling of tool version from worker refactor

### DIFF
--- a/app/controllers/bacons_controller.rb
+++ b/app/controllers/bacons_controller.rb
@@ -12,7 +12,8 @@ class BaconsController < ApplicationController
     end
 
     # Store the number of runs per action
-    Resque.enqueue(BaconUpdaterWorker, launches, params[:error], params[:crash])
+    versions = JSON.parse(params[:versions]) rescue {}
+    Resque.enqueue(BaconUpdaterWorker, launches, versions, params[:error], params[:crash])
 
     send_analytic_ingester_event(params[:fastfile_id], params[:error], params[:crash], launches, Time.now.to_i)
 


### PR DESCRIPTION
The extraction of the bacon SQL handling into the worker caused a regression that is making all tool versions be recorded as 'unknown'.

This fixes this by correctly handing the versions information into the job.