### PR TITLE
Include version info with ana-ing events

### DIFF
--- a/app/controllers/bacons_controller.rb
+++ b/app/controllers/bacons_controller.rb
@@ -15,17 +15,17 @@ class BaconsController < ApplicationController
     parsed_versions = JSON.parse(params[:versions]) rescue {}
     Resque.enqueue(BaconUpdaterWorker, launches, params[:error], params[:crash], parsed_versions)
 
-    send_analytic_ingester_event(params[:fastfile_id], params[:error], params[:crash], launches, Time.now.to_i)
+    send_analytic_ingester_event(params[:fastfile_id], params[:error], params[:crash], launches, Time.now.to_i, parsed_versions)
 
     render json: { success: true }
   end
 
   # This helps us track the success/failure of Fastfiles which are generated
   # by an automated process, such as fastlane web onboarding
-  def send_analytic_ingester_event(fastfile_id, error, crash, launches, timestamp_seconds)
+  def send_analytic_ingester_event(fastfile_id, error, crash, launches, timestamp_seconds, parsed_versions)
     return unless ENV['ANALYTIC_INGESTER_URL'].present?
 
-    Resque.enqueue(AnalyticIngesterWorker, fastfile_id, error, crash, launches, timestamp_seconds)
+    Resque.enqueue(AnalyticIngesterWorker, fastfile_id, error, crash, launches, timestamp_seconds, parsed_versions)
   end
 
   def stats

--- a/app/workers/analytic_ingester_worker.rb
+++ b/app/workers/analytic_ingester_worker.rb
@@ -3,7 +3,7 @@ require 'faraday'
 class AnalyticIngesterWorker
   @queue = :analytic_ingester
 
-  def self.perform(fastfile_id, error, crash, launches, timestamp_seconds)
+  def self.perform(fastfile_id, error, crash, launches, timestamp_seconds, versions={})
     start = Time.now
 
     analytics = []
@@ -14,8 +14,11 @@ class AnalyticIngesterWorker
     end
 
     launches.each do |action, count|
+      action_version = versions[action] || 'unknown'
       action_completion_status = action == crash ? 'crash' : ( action == error ? 'error' : 'success' )
-      analytics << event_for_action_execution(action, count, action_completion_status, timestamp_seconds)
+
+      analytics << event_for_completion(action, action_completion_status, action_version, timestamp_seconds)
+      analytics << event_for_count(action, count, action_version, timestamp_seconds)
     end
 
     analytic_event_body = { analytics: analytics }.to_json
@@ -55,7 +58,7 @@ class AnalyticIngesterWorker
     }
   end
 
-  def self.event_for_action_execution(action, count, completion_status, timestamp_seconds)
+  def self.event_for_completion(action, completion_status, version, timestamp_seconds)
     {
       event_source: {
         oauth_app_name: 'fastlane-enhancer',
@@ -66,15 +69,41 @@ class AnalyticIngesterWorker
         detail: action
       },
       action: {
-        name: 'action_executed'
+        name: 'execution_completed'
       },
       primary_target: {
         name: 'completion_status',
         detail: completion_status
       },
       secondary_target: {
+        name: 'version',
+        detail: version
+      },
+      millis_since_epoch: timestamp_seconds * 1000,
+      version: 1
+    }
+  end
+
+  def self.event_for_count(action, count, version, timestamp_seconds)
+    {
+      event_source: {
+        oauth_app_name: 'fastlane-enhancer',
+        product: 'fastlane'
+      },
+      actor: {
+        name: 'action',
+        detail: action
+      },
+      action: {
+        name: 'execution_counted'
+      },
+      primary_target: {
         name: 'count',
         detail: count.to_s || "1"
+      },
+      secondary_target: {
+        name: 'version',
+        detail: version
       },
       millis_since_epoch: timestamp_seconds * 1000,
       version: 1


### PR DESCRIPTION
* Leave the `fastfile_executed` event as-is. This still reports the `completion_status` for web onboarding.
* Rename `action_executed ` event to `action_completed` and add the `action_version` info to it
* Separate out a `action_counted ` event with the count info that used to be in `action_executed` - include the `action_version` info in it